### PR TITLE
Use SendToTmux in default bindings.

### DIFF
--- a/plugin/tslime.vim
+++ b/plugin/tslime.vim
@@ -120,6 +120,6 @@ endfunction
 
 """"""""""""""""""""""""""""""""""""""""""""""""""""""""""""
 
-execute "vnoremap" . g:tslime_visual_mapping . ' "ry:call Send_to_Tmux(@r)<CR>'
-execute "nnoremap" . g:tslime_normal_mapping . ' vip"ry:call Send_to_Tmux(@r)<CR>'
+execute "vnoremap" . g:tslime_visual_mapping . ' "ry:call SendToTmux(@r)<CR>'
+execute "nnoremap" . g:tslime_normal_mapping . ' vip"ry:call SendToTmux(@r)<CR>'
 execute "nnoremap" . g:tslime_vars_mapping   . ' :call <SID>Tmux_Vars()<CR>'


### PR DESCRIPTION
The Send_to_tmux function doesn't check for newlines, but SendToTmux
does. I've found that the two functions are indistinguishable in
practice for most languages, but when I'm sending to a python repl, I
really want g:tslime_ensure_trailing_newline=2 to be acknowleged.

This also fixes an oddity where sending a small sub-sexpr to a lisp
repl didn't append a newline. With this fix, it will.